### PR TITLE
Modfiy hack host header parsing to use 0 allocs

### DIFF
--- a/cmd/dockerd/daemon_unix.go
+++ b/cmd/dockerd/daemon_unix.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/docker/docker/cmd/dockerd/hack"
 	"github.com/docker/docker/daemon"
 	"github.com/docker/docker/libcontainerd"
 	"github.com/docker/docker/pkg/listeners"
@@ -123,10 +124,10 @@ func initListeners(proto, addr, socketGroup string, tlsConfig *tls.Config) ([]ne
 	if invalidHostHeaderHack {
 		switch proto {
 		case "unix":
-			ls[0] = &MalformedHostHeaderOverride{ls[0]}
+			ls[0] = &hack.MalformedHostHeaderOverride{ls[0]}
 		case "fd":
 			for i := range ls {
-				ls[i] = &MalformedHostHeaderOverride{ls[i]}
+				ls[i] = &hack.MalformedHostHeaderOverride{ls[i]}
 			}
 		}
 	}

--- a/cmd/dockerd/hack/malformed_host_override_test.go
+++ b/cmd/dockerd/hack/malformed_host_override_test.go
@@ -1,0 +1,65 @@
+package hack
+
+import (
+	"io"
+	"net"
+	"testing"
+)
+
+func BenchmarkWithHack(b *testing.B) {
+	client, srv := net.Pipe()
+	done := make(chan struct{})
+	req := []byte("GET /foo\nHost: /var/run/docker.sock\nUser-Agent: Docker\n")
+	read := make([]byte, 4096)
+	b.SetBytes(int64(len(req) * 30))
+
+	l := MalformedHostHeaderOverrideConn{client, true}
+	go func() {
+		for {
+			if _, err := srv.Write(req); err != nil {
+				srv.Close()
+				break
+			}
+			l.first = true // make sure each subsequent run uses the hack parsing
+		}
+		close(done)
+	}()
+
+	for i := 0; i < b.N; i++ {
+		for i := 0; i < 30; i++ {
+			if n, err := l.Read(read); err != nil && err != io.EOF || n != len(req) {
+				b.Fatalf("read: %d - %d, err: %v\n%s", n, len(req), err, string(read[:n]))
+			}
+		}
+	}
+	l.Close()
+	<-done
+}
+
+func BenchmarkNoHack(b *testing.B) {
+	client, srv := net.Pipe()
+	done := make(chan struct{})
+	req := []byte("GET /foo\nHost: /var/run/docker.sock\nUser-Agent: Docker\n")
+	read := make([]byte, 4096)
+	b.SetBytes(int64(len(req) * 30))
+
+	go func() {
+		for {
+			if _, err := srv.Write(req); err != nil {
+				srv.Close()
+				break
+			}
+		}
+		close(done)
+	}()
+
+	for i := 0; i < b.N; i++ {
+		for i := 0; i < 30; i++ {
+			if _, err := client.Read(read); err != nil && err != io.EOF {
+				b.Fatal(err)
+			}
+		}
+	}
+	client.Close()
+	<-done
+}


### PR DESCRIPTION
[]byte->string and string->[]byte conversions tend to create lots of
garbage and are (relatively) slow compared to just sticking with bytes.
Also generic byte ops like `bytes.Split` are really expensive (although
less expensive than a regexp).

Since we already know the exact format we're expecting to get, let's the
parsing manually instead of relying on the bytes/strings package.

This makes the overhead of the header parsing nearly nil.

```
benchmark               old ns/op     new ns/op     delta
BenchmarkWithHack-8     67039         31338         -53.25%
BenchmarkNoHack-8       29701         29453         -0.83%

benchmark               old MB/s     new MB/s     speedup
BenchmarkWithHack-8     24.61        52.65        2.14x
BenchmarkNoHack-8       55.55        56.02        1.01x

benchmark               old allocs     new allocs     delta
BenchmarkWithHack-8     239            0              -100.00%
BenchmarkNoHack-8       0              0              +0.00%

benchmark               old bytes     new bytes     delta
BenchmarkWithHack-8     16309         0             -100.00%
BenchmarkNoHack-8       0             0             +0.00%
```

Signed-off-by: Brian Goff cpuguy83@gmail.com
